### PR TITLE
Increment with value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "6"

--- a/README.md
+++ b/README.md
@@ -41,13 +41,17 @@ node app
 
 ```
 /statsd/:node/increment?token=xxx
+/statsd/:node/increment/:delta?token=xxx
 ```
 
 example
 
 ```
 /statsd/raoul/increment?token=xxx
+/statsd/raoul/increment/123?token=xxx
 ```
+
+delta value specifies by how much counter is modified
 
 ### timer
 

--- a/app.js
+++ b/app.js
@@ -33,7 +33,13 @@ app.get('/check', function (req, res){
 
 app.get('/statsd/:node/increment',
     ratelimit,
-    middleware.securityToken(security),
+    //middleware.securityToken(security),
+    statsdRouting.increment
+);
+
+app.get('/statsd/:node/increment/:delta',
+    ratelimit,
+    //middleware.securityToken(security, {valueParameter: 'delta'}),
     statsdRouting.increment
 );
 

--- a/app.js
+++ b/app.js
@@ -33,13 +33,13 @@ app.get('/check', function (req, res){
 
 app.get('/statsd/:node/increment',
     ratelimit,
-    //middleware.securityToken(security),
+    middleware.securityToken(security),
     statsdRouting.increment
 );
 
 app.get('/statsd/:node/increment/:delta',
     ratelimit,
-    //middleware.securityToken(security, {valueParameter: 'delta'}),
+    middleware.securityToken(security, {valueParameter: 'delta'}),
     statsdRouting.increment
 );
 

--- a/lib/routes/statsd.js
+++ b/lib/routes/statsd.js
@@ -4,7 +4,7 @@ module.exports = function(clientStatsd, config) {
 
     routes.increment = function(req, res) {
         // fire the increment
-        clientStatsd.increment(req.params.node);
+        clientStatsd.increment(req.params.node, req.params.delta);
 
         res.setHeader('Content-Type', 'image/jpeg');
         res.setHeader('Content-Length', 0);

--- a/lib/routes/statsd.js
+++ b/lib/routes/statsd.js
@@ -34,7 +34,6 @@ module.exports = function(clientStatsd, config) {
         res.setHeader('Content-Length', 0);
         res.status(204).send('');
         if (config.monitoringNodeBase && config.monitoringNodeBase !== 'undefined') {
-
             clientStatsd.increment(config.monitoringNodeBase + '.timing');
         }
     };
@@ -47,7 +46,6 @@ module.exports = function(clientStatsd, config) {
         res.setHeader('Content-Length', 0);
         res.status(204).send('');
         if (config.monitoringNodeBase && config.monitoringNodeBase !== 'undefined') {
-
             clientStatsd.increment(config.monitoringNodeBase + '.gauge');
         }
     };
@@ -60,7 +58,6 @@ module.exports = function(clientStatsd, config) {
         res.setHeader('Content-Length', 0);
         res.status(204).send('');
         if (config.monitoringNodeBase && config.monitoringNodeBase !== 'undefined') {
-
             clientStatsd.increment(config.monitoringNodeBase + '.set');
         }
     };

--- a/lib/statsd/statsdAggregator.js
+++ b/lib/statsd/statsdAggregator.js
@@ -39,13 +39,13 @@ StatsdAggregator.prototype._timeoutMetric = function(metric) {
 StatsdAggregator.prototype.increment = function(metricName, delta) {
     var metric = this._getMetric(metricName);
 
-    if(typeof(delta) === "undefined") {
+    if(typeof delta === "undefined") {
         // Default delta value is increment by 1
-        metric.value++;
+        ++metric.value;
     }
     else {
         // If delta value is provided then increment by delta
-        metric.value += Number.parseInt(delta);
+        metric.value += parseInt(delta);
     }
 };
 

--- a/lib/statsd/statsdAggregator.js
+++ b/lib/statsd/statsdAggregator.js
@@ -28,9 +28,6 @@ StatsdAggregator.prototype._timeoutMetric = function(metric) {
 
     setTimeout(function() {
         // fire increment
-        console.log("Metric flushed!");
-        console.log("  name: " + metric.metric);
-        console.log("  value: " + metric.value);
         _this.statdsClient.increment(metric.metric, metric.value);
         _this.metrics = _.without(_this.metrics, metric);
     }, this.timeout);

--- a/lib/statsd/statsdAggregator.js
+++ b/lib/statsd/statsdAggregator.js
@@ -27,8 +27,11 @@ StatsdAggregator.prototype._timeoutMetric = function(metric) {
     var _this = this;
 
     setTimeout(function() {
-        // fire increment
-        _this.statdsClient.increment(metric.metric, metric.value);
+        // This condition is because StatsD client for 0 delta fallbacks to increment by 1
+        if(metric.value) {
+            // fire increment
+            _this.statdsClient.increment(metric.metric, metric.value);
+        }
         _this.metrics = _.without(_this.metrics, metric);
     }, this.timeout);
 };
@@ -37,9 +40,11 @@ StatsdAggregator.prototype.increment = function(metricName, delta) {
     var metric = this._getMetric(metricName);
 
     if(typeof(delta) === "undefined") {
+        // Default delta value is increment by 1
         metric.value++;
     }
     else {
+        // If delta value is provided then increment by delta
         metric.value += Number.parseInt(delta);
     }
 };

--- a/lib/statsd/statsdAggregator.js
+++ b/lib/statsd/statsdAggregator.js
@@ -28,15 +28,23 @@ StatsdAggregator.prototype._timeoutMetric = function(metric) {
 
     setTimeout(function() {
         // fire increment
+        console.log("Metric flushed!");
+        console.log("  name: " + metric.metric);
+        console.log("  value: " + metric.value);
         _this.statdsClient.increment(metric.metric, metric.value);
         _this.metrics = _.without(_this.metrics, metric);
     }, this.timeout);
 };
 
-StatsdAggregator.prototype.increment = function(metricName) {
+StatsdAggregator.prototype.increment = function(metricName, delta) {
     var metric = this._getMetric(metricName);
 
-    metric.value++;
+    if(typeof(delta) === "undefined") {
+        metric.value++;
+    }
+    else {
+        metric.value += Number.parseInt(delta);
+    }
 };
 
 StatsdAggregator.prototype.decrement = function(metricName) {

--- a/test/routes/statsd.js
+++ b/test/routes/statsd.js
@@ -24,6 +24,7 @@
     // Test server
     var app = express();
     app.get('/statsd/:node/increment', statsdRoutes.increment);
+    app.get('/statsd/:node/increment/:delta', statsdRoutes.increment);
     app.get('/statsd/:node/decrement', statsdRoutes.decrement);
     app.get('/statsd/:node/timer/:timing', statsdRoutes.timing);
     app.get('/statsd/:node/gauge/:gauge', statsdRoutes.gauge);
@@ -55,6 +56,16 @@
                 .expect(204)
                 .end(function() {
                     mockedClientStatsd.increment.should.have.been.calledWith('test');
+                    done();
+                });
+        });
+
+        it('should return a 204 and call statsdClient.increment with delta on increment', function(done){
+            request(app)
+                .get('/statsd/test/increment/123')
+                .expect(204)
+                .end(function() {
+                    mockedClientStatsd.increment.should.have.been.calledWith('test', '123');
                     done();
                 });
         });

--- a/test/statsd/statsdAggregator.js
+++ b/test/statsd/statsdAggregator.js
@@ -57,4 +57,15 @@ describe('Test statsdAggregator', function () {
         }, 500);
 
     });
+
+    it('should call statd client increment with value 123 when increment was called with delta 123', function(done) {
+        var statsdAggregator = new StatsdAggregator(mockedClientStatsd, 100);
+
+        statsdAggregator.increment('raoul', '123');
+
+        setTimeout(function() {
+            mockedClientStatsd.increment.should.have.been.calledWith('raoul', 123);
+            done();
+        }, 500);
+    });
 });


### PR DESCRIPTION
Increment endpoint extended to support delta value by how much to increment. For value 0 (aggregated over time by aggregator) call to StatsD JS client is omitted as it does not support increment with 0 (it falls back to 1 if given value is JS-falsie).